### PR TITLE
removed weak_module, weak_script_method

### DIFF
--- a/vedaseg/models/utils/act.py
+++ b/vedaseg/models/utils/act.py
@@ -3,10 +3,8 @@
 import torch
 import torch.nn as nn
 from torch.nn.parameter import Parameter
-from torch._jit_internal import weak_module, weak_script_method
 
 
-@weak_module
 class TLU(nn.Module):
     def __init__(self, num_features):
         super(TLU, self).__init__()
@@ -19,7 +17,6 @@ class TLU(nn.Module):
     def reset_parameters(self):
         nn.init.zeros_(self.tau)
 
-    @weak_script_method
     def forward(self, x):
         return torch.max(x, self.tau)
 

--- a/vedaseg/models/utils/norm.py
+++ b/vedaseg/models/utils/norm.py
@@ -3,10 +3,8 @@
 import torch
 import torch.nn as nn
 from torch.nn.parameter import Parameter
-from torch._jit_internal import weak_module, weak_script_method
 
 
-@weak_module
 class FRN(nn.Module):
     def __init__(self, num_features, eps=1e-6):
         super(FRN, self).__init__()
@@ -23,7 +21,6 @@ class FRN(nn.Module):
         nn.init.ones_(self.gamma)
         nn.init.zeros_(self.beta)
 
-    @weak_script_method
     def forward(self, x):
         nu2 = torch.mean(x.pow(2), dim=[2,3], keepdim=True)
         x = x * torch.rsqrt(nu2 + self.eps.abs())

--- a/vedaseg/models/utils/upsample.py
+++ b/vedaseg/models/utils/upsample.py
@@ -1,13 +1,11 @@
 import torch.nn as nn
 import torch.nn.functional as F
-from torch._jit_internal import weak_module, weak_script_method
 
 
 from .registry import UTILS
 
 
 @UTILS.register_module
-@weak_module
 class Upsample(nn.Module):
     __constants__ = ['size', 'scale_factor', 'scale_bias', 'mode', 'align_corners', 'name']
 
@@ -21,7 +19,6 @@ class Upsample(nn.Module):
 
         assert (self.size is None) ^ (self.scale_factor is None)
 
-    @weak_script_method
     def forward(self, x):
         if self.size:
             size = self.size


### PR DESCRIPTION
According to [pytorch update](https://github.com/pytorch/pytorch/commit/10c4b98ade8349d841518d22f19a653a939e260c#diff-ee07db084d958260fd24b4b02d4f078d): `weak_module` , `weak_script_method`  no longer exist in `torch._jit_internal`.
fix according to [this discussion](https://discuss.pytorch.org/t/unable-to-import-weak-module/60289/6)