### PR TITLE
bugfix: improper if statement

### DIFF
--- a/vedaseg/runners/base.py
+++ b/vedaseg/runners/base.py
@@ -61,7 +61,7 @@ class Common:
         return use_gpu
 
     def _set_seed(self, seed):
-        if seed:
+        if seed is not None:
             self.logger.info('Set seed {}'.format(seed))
             random.seed(seed)
             np.random.seed(seed)


### PR DESCRIPTION
Currently, random seeds in configs are set to 0 by default and in that case, no seed will be set.