### PR TITLE
typo-fix & readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The major configuration difference between single-label and multi-label training
 python tools/train.py configs/voc_unet.py
 ```
 
-Snapshots and logs by default will be generated at `${vedaseg_root}/workdir`(you can specify workdir in config files).
+Snapshots and logs by default will be generated at `${vedaseg_root}/workdir/name_of_config_file`(you can specify workdir in config files).
 
 ## Test
 

--- a/tools/dist_test.sh
+++ b/tools/dist_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if (($# < 2)); then
+if (($# < 3)); then
   echo "Uasage: bash tools/dist_test.sh config_file checkpoint gpus_to_use"
   exit 1
 fi


### PR DESCRIPTION
1. Update workdir location in the readme file.
2. Inaccurate argument number check in dist training script.